### PR TITLE
netstat flag fix, local vs remote port fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,10 @@ module.exports = function (port, method = 'tcp') {
   }
 
   if (process.platform === 'win32') {
-    return sh(`netstat -ao | findStr ${method.toUpperCase()}.*:${port}`)
+    // The second white-space delimited column of netstat output is the local port,
+    // which is the only port we care about.
+    // The findStr "regex" here will match only the local port column of the output
+    return sh(`netstat -nao | findStr /r /c:"^ *${method.toUpperCase()} *[^ ]*:${port}`)
       .then(res => {
         const { stdout } = res
         if (!stdout) return res

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = function (port, method = 'tcp') {
     // The second white-space delimited column of netstat output is the local port,
     // which is the only port we care about.
     // The findStr "regex" here will match only the local port column of the output
-    return sh(`netstat -nao | findStr /r /c:"^ *${method.toUpperCase()} *[^ ]*:${port}`)
+    return sh(`netstat -nao | findStr /r /c:"^ *${method.toUpperCase()} *[^ ]*:${port}"`)
       .then(res => {
         const { stdout } = res
         if (!stdout) return res


### PR DESCRIPTION
Hopefully fixes #3 

`netstat` should get the -n parameter so it doesn't try to come up with a human readable name for ip addresses, which can take a long time and isn't needed.

The `findStr` regex should match only the first column of output from `netstat` because we only care about local ports and definitely don't won't to kill processes connected to a remote port that happens to be the port we provided.