### PR TITLE
Don't reverse lookup hostnames in *nix

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,6 @@ module.exports = function (port, method = 'tcp') {
   }
 
   return sh(
-    `lsof -i ${method === 'udp' ? 'udp' : 'tcp'}:${port} | grep ${method === 'udp' ? 'UDP' : 'LISTEN'} | awk '{print $2}' | xargs kill -9`
+    `lsof -ni ${method === 'udp' ? 'udp' : 'tcp'}:${port} | grep ${method === 'udp' ? 'UDP' : 'LISTEN'} | awk '{print $2}' | xargs kill -9`
   )
 }


### PR DESCRIPTION
#39 stopped rDNS lookups in Windows, but not Linux.  As such, `lsof` may take some time to return depending on the IPs connected to the bound port.  This PR stops DNS lookups.