### PR TITLE
Add `--quiet` CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,16 @@ $ kill-port --port 8080,5000,3000
 $ kill-port 9000 3000 5000
 ```
 
+Other CLI options:
+
+```sh
+# Skips logging information to console
+$ kill-port --quiet 8080
+
+# Logs kill result to console
+$ kill-port --verbose 8080
+```
+
 You can also use [npx](https://nodejs.dev/learn/the-npx-nodejs-package-runner) to `kill-port` without installing:
 
 ```sh

--- a/cli.js
+++ b/cli.js
@@ -4,6 +4,7 @@
 const kill = require('./')
 const args = require('get-them-args')(process.argv.slice(2))
 
+const quiet = args.verbose || false
 const verbose = args.verbose || false
 let port = args.port ? args.port.toString().split(',') : args.unknown
 const method = args.method || 'tcp'
@@ -14,12 +15,12 @@ if (!Array.isArray(port)) {
 
 Promise.all(port.map(current => {
   return kill(current, method)
-    .then((result) => {
-      console.log(`Process on port ${current} killed`)
+    .then(result => {
+      quiet || console.log(`Process on port ${current} killed.`)
       verbose && console.log(result)
     })
-    .catch((error) => {
-      console.log(`Could not kill process on port ${port}. ${error.message}.`)
+    .catch(error => {
+      quiet || console.log(`Could not kill process on port ${port}. ${error.message}.`)
       verbose && console.log(error)
     })
 }))


### PR DESCRIPTION
I think this would be nice to have to help reduce non-essential terminal logs.