### PR TITLE
Add a signal selection option

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ const server = http.createServer((req, res) => {
 
 server.listen(port, () => {
   setTimeout(() => {
-    
     // Currently you can kill ports running on TCP or UDP protocols
     kill(port, 'tcp')
       .then(console.log)
@@ -108,6 +107,8 @@ $ kill-port --port 8080
 $ kill-port 9000
 # OR you can use UDP
 $ kill-port 9000 --method udp
+# OR you can use SIGTERM
+$ kill-port --signal SIGTERM 9000
 ```
 
 You can also kill multiple ports:

--- a/cli.js
+++ b/cli.js
@@ -5,6 +5,7 @@ const kill = require('./')
 const args = require('get-them-args')(process.argv.slice(2))
 
 const verbose = args.verbose || false
+const signal = args.signal || '9'
 let port = args.port ? args.port.toString().split(',') : args.unknown
 const method = args.method || 'tcp'
 
@@ -13,7 +14,7 @@ if (!Array.isArray(port)) {
 }
 
 Promise.all(port.map(current => {
-  return kill(current, method)
+  return kill(current, method, signal)
     .then((result) => {
       console.log(`Process on port ${current} killed`)
       verbose && console.log(result)

--- a/cli.js
+++ b/cli.js
@@ -5,9 +5,10 @@ const kill = require('./')
 const args = require('get-them-args')(process.argv.slice(2))
 
 const verbose = args.verbose || false
-const signal = args.signal || '15'
-let port = args.port ? args.port.toString().split(',') : args.unknown
+const signal = args.signal || 'SIGKILL'
 const method = args.method || 'tcp'
+
+let port = args.port ? args.port.toString().split(',') : args.unknown
 
 if (!Array.isArray(port)) {
   port = [port]
@@ -16,7 +17,7 @@ if (!Array.isArray(port)) {
 Promise.all(port.map(current => {
   return kill(current, method, signal)
     .then((result) => {
-      console.log(`Process on port ${current}:${method} killed using signal ${signal}`)
+      console.log(`Process on ${method} port ${current} killed using signal ${signal}`)
       verbose && console.log(result)
     })
     .catch((error) => {

--- a/cli.js
+++ b/cli.js
@@ -5,7 +5,7 @@ const kill = require('./')
 const args = require('get-them-args')(process.argv.slice(2))
 
 const verbose = args.verbose || false
-const signal = args.signal || '9'
+const signal = args.signal || '15'
 let port = args.port ? args.port.toString().split(',') : args.unknown
 const method = args.method || 'tcp'
 
@@ -16,7 +16,7 @@ if (!Array.isArray(port)) {
 Promise.all(port.map(current => {
   return kill(current, method, signal)
     .then((result) => {
-      console.log(`Process on port ${current} killed`)
+      console.log(`Process on port ${current}:${method} killed using signal ${signal}`)
       verbose && console.log(result)
     })
     .catch((error) => {

--- a/index.js
+++ b/index.js
@@ -51,14 +51,14 @@ module.exports = function (port, method = 'tcp', signal = 'SIGKILL') {
 }
 
 function mapSignalToNumber(signal) {
-	const signals = {
-		SIGHUP: 1,
-		SIGINT: 2,
-		SIGQUIT: 3,
-		SIGABRT: 6,
-		SIGKILL: 9,
-		SIGTERM: 15
-	}
+  const signals = {
+    SIGHUP: 1,
+    SIGINT: 2,
+    SIGQUIT: 3,
+    SIGABRT: 6,
+    SIGKILL: 9,
+    SIGTERM: 15
+  }
 
-	return signals[signal]
+  return signals[signal]
 }

--- a/index.js
+++ b/index.js
@@ -2,11 +2,16 @@
 
 const sh = require('shell-exec')
 
-module.exports = function (port, method = 'tcp') {
+module.exports = function (port, method = 'tcp', signal = '9') {
   port = Number.parseInt(port)
+	signal = Number.parseInt(signal)
 
   if (!port) {
     return Promise.reject(new Error('Invalid port number provided'))
+  }
+
+	if (!signal) {
+    return Promise.reject(new Error('Invalid signal number provided'))
   }
 
   if (process.platform === 'win32') {
@@ -40,7 +45,7 @@ module.exports = function (port, method = 'tcp') {
       if (!existProccess) return Promise.reject(new Error('No process running on port'))
 
       return sh(
-        `lsof -i ${method === 'udp' ? 'udp' : 'tcp'}:${port} | grep ${method === 'udp' ? 'UDP' : 'LISTEN'} | awk '{print $2}' | xargs kill -9`
+        `lsof -i ${method === 'udp' ? 'udp' : 'tcp'}:${port} | grep ${method === 'udp' ? 'UDP' : 'LISTEN'} | awk '{print $2}' | xargs kill -${signal}`
       )
     })
 }

--- a/index.js
+++ b/index.js
@@ -2,16 +2,16 @@
 
 const sh = require('shell-exec')
 
-module.exports = function (port, method = 'tcp', signal = '15') {
+module.exports = function (port, method = 'tcp', signal = 'SIGKILL') {
   port = Number.parseInt(port)
-	signal = Number.parseInt(signal)
+  signal = mapSignalToNumber(signal)
 
   if (!port) {
     return Promise.reject(new Error('Invalid port number provided'))
   }
 
-	if (!signal) {
-    return Promise.reject(new Error('Invalid signal number provided'))
+  if (!signal) {
+    return Promise.reject(new Error('Invalid signal name provided'))
   }
 
   if (process.platform === 'win32') {
@@ -48,4 +48,17 @@ module.exports = function (port, method = 'tcp', signal = '15') {
         `lsof -i ${method === 'udp' ? 'udp' : 'tcp'}:${port} | grep ${method === 'udp' ? 'UDP' : 'LISTEN'} | awk '{print $2}' | xargs kill -${signal}`
       )
     })
+}
+
+function mapSignalToNumber(signal) {
+  const signals = {
+		SIGHUP: 1,
+		SIGINT: 2,
+		SIGQUIT: 3,
+		SIGABRT: 6,
+    SIGKILL: 9,
+		SIGTERM: 15
+  }
+
+  return signals[signal]
 }

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const sh = require('shell-exec')
 
-module.exports = function (port, method = 'tcp', signal = '9') {
+module.exports = function (port, method = 'tcp', signal = '15') {
   port = Number.parseInt(port)
 	signal = Number.parseInt(signal)
 

--- a/index.js
+++ b/index.js
@@ -51,14 +51,14 @@ module.exports = function (port, method = 'tcp', signal = 'SIGKILL') {
 }
 
 function mapSignalToNumber(signal) {
-  const signals = {
+	const signals = {
 		SIGHUP: 1,
 		SIGINT: 2,
 		SIGQUIT: 3,
 		SIGABRT: 6,
-    SIGKILL: 9,
+		SIGKILL: 9,
 		SIGTERM: 15
-  }
+	}
 
-  return signals[signal]
+	return signals[signal]
 }

--- a/test.js
+++ b/test.js
@@ -7,7 +7,11 @@ describe('kill-port', () => {
   })
 
   test('should throw if no port is provided', () => {
-    expect(kill()).rejects.toThrow()
+    expect(kill()).rejects.toThrow('Invalid port number provided')
+  })
+
+  test('should throw if invalid signal is provided', () => {
+    expect(kill(9999, 'tcp', 'BADSIG')).rejects.toThrow('Invalid signal name provided')
   })
 
   test('should throw if no process running on given port', () => {


### PR DESCRIPTION
Adds the ability to pass a `--signal` along with one of the following names SIGHUP, SIGINT, SIGQUIT, SIGABRT, SIGKILL, SIGTERM. 

The specified signal will then be passed to `kill` instead of the default `SIGKILL`/9. 

Usage:

`kill-port --signal SIGTERM 9000`
