### PR TITLE
Speed up the kill process by only listing the port of interest with lsof

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = function (port, method = 'tcp') {
       })
   }
 
-  return sh('lsof -i -P')
+  return sh(`lsof -i :${port} -P`)
     .then(res => {
       const { stdout } = res
       if (!stdout) return res


### PR DESCRIPTION
Without that filter limit, the module tries to list ALL of the ports open on a system, and it can take 10s or even more at times.

With this flag, we won't bother `lsof` gathering info on other ports that we're going to discard anyway